### PR TITLE
test: broken Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PATH="/root/.local/bin:/app/.venv/bin:$PATH"
 COPY . .
 
 # Install dependencies into .venv
-RUN uv sync
+RUN uv syn
 
 # Start the FastAPI app
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
### 故意製造錯誤的 Dockerfile 來測試 CI 偵錯功能

- 作法：將原本的 `RUN uv sync` 改為錯誤指令 `RUN uv syn`。
- 預期效果：
  - CI 會在這個步驟出現失敗訊息
  - Actions log 中會看到錯誤提示
  - 測試 GitHub Actions 能否正確攔截錯誤 build